### PR TITLE
Add TestDirectiveComponent unit tests

### DIFF
--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -1,10 +1,12 @@
 import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
 import { App } from './app';
 
 describe('App', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [App],
+      providers: [provideRouter([])],
     }).compileComponents();
   });
 

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,8 +1,9 @@
 import { Component, signal } from '@angular/core';
+import { RouterOutlet } from '@angular/router';
 
 @Component({
   selector: 'app-root',
-  standalone: false,
+  imports: [RouterOutlet],
   templateUrl: './app.html',
   styleUrl: './app.css'
 })

--- a/src/app/components/test-directive/test-directive.component.spec.ts
+++ b/src/app/components/test-directive/test-directive.component.spec.ts
@@ -1,0 +1,39 @@
+import { TestBed } from '@angular/core/testing';
+import { VERSION } from '@angular/core';
+import { TestDirectiveComponent } from './test-directive.component';
+
+describe('TestDirectiveComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestDirectiveComponent],
+    }).compileComponents();
+  });
+
+  it('should create the component', () => {
+    const fixture = TestBed.createComponent(TestDirectiveComponent);
+    const component = fixture.componentInstance;
+    expect(component).toBeTruthy();
+  });
+
+  it('should have version equal to VERSION.full', () => {
+    const fixture = TestBed.createComponent(TestDirectiveComponent);
+    const component = fixture.componentInstance;
+    expect(component.version).toBe(VERSION.full);
+  });
+
+  it('should render a div with data-testid containing the version string', async () => {
+    const fixture = TestBed.createComponent(TestDirectiveComponent);
+    await fixture.whenStable();
+    const compiled = fixture.nativeElement as HTMLElement;
+    const div = compiled.querySelector('div[data-testid="angular-version-directive"]');
+    expect(div).toBeTruthy();
+    expect(div!.textContent).toContain(VERSION.full);
+  });
+
+  it('should call console.info with initialization message in constructor', () => {
+    const spy = vi.spyOn(console, 'info');
+    TestBed.createComponent(TestDirectiveComponent);
+    expect(spy).toHaveBeenCalledWith('test-directive initialized...');
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

Adds `src/app/components/test-directive/test-directive.component.spec.ts` with four test cases:

- Component creates successfully
- `version` property equals `VERSION.full`
- Template renders `div[data-testid="angular-version-directive"]` containing the version string
- Constructor calls `console.info('test-directive initialized...')`

Also fixes a pre-existing build error: `App` component referenced `<router-outlet />` in its template without importing `RouterOutlet`. Fixed by adding `imports: [RouterOutlet]` to `App` and `provideRouter([])` to the existing `app.spec.ts`.

All 6 tests pass (4 new + 2 existing).

Link to Devin session: https://app.devin.ai/sessions/42d8be5018fb44b9b4849e2ad9f2d8c2
Requested by: @devanshi-gpta
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angularjs-asp-net48-mvc5/pull/95?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angularjs-asp-net48-mvc5/pull/95" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->