### PR TITLE
Add spec files for AppModule and routes config

### DIFF
--- a/src/app/app.module.spec.ts
+++ b/src/app/app.module.spec.ts
@@ -1,0 +1,39 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { AppModule } from './app.module';
+import { App } from './app';
+import { TestComponent } from './components/test/test.component';
+import { TestDirectiveComponent } from './components/test-directive/test-directive.component';
+import { routes } from './app.routes';
+
+describe('AppModule', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AppModule],
+    }).compileComponents();
+  });
+
+  it('should compile without errors', () => {
+    const module = TestBed.inject(AppModule);
+    expect(module).toBeTruthy();
+  });
+
+  it('should have App in declarations', () => {
+    const fixture = TestBed.createComponent(App);
+    expect(fixture.componentInstance).toBeInstanceOf(App);
+  });
+
+  it('should import TestComponent and TestDirectiveComponent', () => {
+    const testFixture = TestBed.createComponent(TestComponent);
+    expect(testFixture.componentInstance).toBeInstanceOf(TestComponent);
+
+    const directiveFixture = TestBed.createComponent(TestDirectiveComponent);
+    expect(directiveFixture.componentInstance).toBeInstanceOf(TestDirectiveComponent);
+  });
+
+  it('should configure RouterModule.forRoot(routes)', () => {
+    const router = TestBed.inject(Router);
+    expect(router).toBeTruthy();
+    expect(router.config).toEqual(routes);
+  });
+});

--- a/src/app/app.routes.spec.ts
+++ b/src/app/app.routes.spec.ts
@@ -1,0 +1,7 @@
+import { routes } from './app.routes';
+
+describe('routes', () => {
+  it('should be an empty array', () => {
+    expect(routes).toEqual([]);
+  });
+});

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -1,10 +1,12 @@
 import { TestBed } from '@angular/core/testing';
+import { RouterModule } from '@angular/router';
 import { App } from './app';
 
 describe('App', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [App],
+      declarations: [App],
+      imports: [RouterModule.forRoot([])],
     }).compileComponents();
   });
 


### PR DESCRIPTION
## Summary

Adds unit tests for `AppModule` and the routes configuration, and fixes a pre-existing failure in `app.spec.ts`.

**New files:**
- `src/app/app.module.spec.ts` — tests that `AppModule` compiles, `App` is in `declarations`, `TestComponent`/`TestDirectiveComponent` are in `imports`, and `RouterModule.forRoot(routes)` is configured.
- `src/app/app.routes.spec.ts` — tests that `routes` is an empty array.

**Fix to existing test:**
- `src/app/app.spec.ts` — `App` has `standalone: false`, so changed `imports: [App]` → `declarations: [App]` and added `imports: [RouterModule.forRoot([])]` to satisfy the `<router-outlet>` in the template.

All 7 tests pass (`npm test`).

Link to Devin session: https://app.devin.ai/sessions/1467a49de52f47369046474e95f8b635
Requested by: @devanshi-gpta
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angularjs-asp-net48-mvc5/pull/96?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angularjs-asp-net48-mvc5/pull/96" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->