### PR TITLE
Add .NET Framework 4.8 unit test project (NUnit)

### DIFF
--- a/Tests/LandingControllerTests.cs
+++ b/Tests/LandingControllerTests.cs
@@ -1,0 +1,31 @@
+using System.Web.Mvc;
+using NUnit.Framework;
+using asp_net_angularjs.Controllers;
+
+namespace asp_net_angularjs.Tests
+{
+    [TestFixture]
+    public class LandingControllerTests
+    {
+        [Test]
+        public void Index_ReturnsViewResult()
+        {
+            var controller = new LandingController();
+
+            var result = controller.Index();
+
+            Assert.That(result, Is.InstanceOf<ViewResult>());
+        }
+
+        [Test]
+        public void Index_ReturnsDefaultView()
+        {
+            var controller = new LandingController();
+
+            var result = controller.Index() as ViewResult;
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(string.IsNullOrEmpty(result.ViewName), Is.True);
+        }
+    }
+}

--- a/Tests/RouteConfigTests.cs
+++ b/Tests/RouteConfigTests.cs
@@ -1,0 +1,51 @@
+using System.Web;
+using System.Web.Routing;
+using NUnit.Framework;
+
+namespace asp_net_angularjs.Tests
+{
+    [TestFixture]
+    public class RouteConfigTests
+    {
+        private RouteCollection _routes;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _routes = new RouteCollection();
+            RouteConfig.RegisterRoutes(_routes);
+        }
+
+        [Test]
+        public void RegisterRoutes_LandingRouteIsRegistered()
+        {
+            Assert.That(_routes["Landing"], Is.Not.Null);
+        }
+
+        [Test]
+        public void RegisterRoutes_RootUrlMapsToLandingControllerIndex()
+        {
+            var httpContextMock = new Moq.Mock<HttpContextBase>();
+            httpContextMock.Setup(c => c.Request.AppRelativeCurrentExecutionFilePath).Returns("~/");
+
+            var routeData = _routes.GetRouteData(httpContextMock.Object);
+
+            Assert.That(routeData, Is.Not.Null);
+            Assert.That(routeData.Values["controller"], Is.EqualTo("Landing"));
+            Assert.That(routeData.Values["action"], Is.EqualTo("Index"));
+        }
+
+        [Test]
+        public void RegisterRoutes_AxdResourcesAreIgnored()
+        {
+            var httpContextMock = new Moq.Mock<HttpContextBase>();
+            httpContextMock.Setup(c => c.Request.AppRelativeCurrentExecutionFilePath).Returns("~/trace.axd");
+            httpContextMock.Setup(c => c.Request.PathInfo).Returns(string.Empty);
+
+            var routeData = _routes.GetRouteData(httpContextMock.Object);
+
+            Assert.That(routeData, Is.Not.Null);
+            Assert.That(routeData.RouteHandler, Is.InstanceOf<StopRoutingHandler>());
+        }
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <RootNamespace>asp_net_angularjs.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.7" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="System.Web" />
+    <Reference Include="System.Web.Routing" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Controllers\LandingController.cs" Link="LinkedSources\LandingController.cs" />
+    <Compile Include="..\App_Start\RouteConfig.cs" Link="LinkedSources\RouteConfig.cs" />
+  </ItemGroup>
+
+</Project>

--- a/angularjs-asp-net48-mvc5.sln
+++ b/angularjs-asp-net48-mvc5.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.1.32210.238
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "angularjs-asp-net48-mvc5", "angularjs-asp-net48-mvc5.csproj", "{43046E18-F0D2-4443-98D5-4650BDCB3A8B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "Tests\Tests.csproj", "{0D9E4357-E0A4-4D56-972B-B53CDD4E6BF9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{43046E18-F0D2-4443-98D5-4650BDCB3A8B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{43046E18-F0D2-4443-98D5-4650BDCB3A8B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{43046E18-F0D2-4443-98D5-4650BDCB3A8B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0D9E4357-E0A4-4D56-972B-B53CDD4E6BF9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0D9E4357-E0A4-4D56-972B-B53CDD4E6BF9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0D9E4357-E0A4-4D56-972B-B53CDD4E6BF9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0D9E4357-E0A4-4D56-972B-B53CDD4E6BF9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary

Adds an SDK-style NUnit test project (`Tests/Tests.csproj`) targeting `net48` with linked source files from the main project.

**LandingControllerTests** — verifies `Index()` returns a `ViewResult` with the default view name (null/empty).

**RouteConfigTests** — verifies:
- The `"Landing"` route is registered in the `RouteCollection`
- Root URL `""` maps to `LandingController.Index`
- `.axd` resources are ignored via `StopRoutingHandler`

Uses `Microsoft.NETFramework.ReferenceAssemblies.net48` for cross-platform build and Moq for `HttpContextBase` mocking in route tests.

Link to Devin session: https://app.devin.ai/sessions/05136a1dbc82448e8b62cfcd04e166f6
Requested by: @devanshi-gpta
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angularjs-asp-net48-mvc5/pull/97?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angularjs-asp-net48-mvc5/pull/97" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->