### PR TITLE
Fix App spec and add TestComponent spec

### DIFF
--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -1,10 +1,13 @@
 import { TestBed } from '@angular/core/testing';
+import { RouterModule } from '@angular/router';
 import { App } from './app';
+import { AppModule } from './app.module';
 
 describe('App', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [App],
+      declarations: [App],
+      imports: [RouterModule.forRoot([])],
     }).compileComponents();
   });
 
@@ -14,10 +17,23 @@ describe('App', () => {
     expect(app).toBeTruthy();
   });
 
+  it(`should have the 'angular-app' title`, () => {
+    const fixture = TestBed.createComponent(App);
+    const app = fixture.componentInstance;
+    expect(app['title']()).toEqual('angular-app');
+  });
+
   it('should render title', async () => {
     const fixture = TestBed.createComponent(App);
     await fixture.whenStable();
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.querySelector('h1')?.textContent).toContain('Hello, angular-app');
+  });
+
+  it('should contain a router-outlet', () => {
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('router-outlet')).toBeTruthy();
   });
 });

--- a/src/app/components/test/test.component.spec.ts
+++ b/src/app/components/test/test.component.spec.ts
@@ -1,0 +1,40 @@
+import { TestBed } from '@angular/core/testing';
+import { VERSION } from '@angular/core';
+import { TestComponent } from './test.component';
+
+describe('TestComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestComponent],
+    }).compileComponents();
+  });
+
+  it('should create the component', () => {
+    const fixture = TestBed.createComponent(TestComponent);
+    const component = fixture.componentInstance;
+    expect(component).toBeTruthy();
+  });
+
+  it('should have version equal to VERSION.full', () => {
+    const fixture = TestBed.createComponent(TestComponent);
+    const component = fixture.componentInstance;
+    expect(component.version).toEqual(VERSION.full);
+  });
+
+  it('should render the version in the template', () => {
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement as HTMLElement;
+    const versionDiv = compiled.querySelector('[data-testid="angular-version"]');
+    expect(versionDiv).toBeTruthy();
+    expect(versionDiv?.textContent).toContain(VERSION.full);
+  });
+
+  it('should call console.info on init', () => {
+    const consoleSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+    expect(consoleSpy).toHaveBeenCalledWith('test-component initialized...');
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

**`app.spec.ts`**: `App` is `standalone: false`, so `imports: [App]` was incorrect. Changed to `declarations: [App]` + `imports: [RouterModule.forRoot([])]` (template uses `<router-outlet />`). Added `import { AppModule }` to bring the module into the AOT compilation scope so the Angular compiler can resolve `router-outlet`. Added two new test cases: `title` signal returns `'angular-app'` and template contains `<router-outlet>`.

**`test.component.spec.ts`** (new): Tests for the standalone `TestComponent` — creation, `version === VERSION.full`, template renders `div[data-testid="angular-version"]` with the version string, and `ngOnInit` calls `console.info('test-component initialized...')`.

Link to Devin session: https://app.devin.ai/sessions/1f8e621cbdbd4ef6a97084ecf1ec0082
Requested by: @devanshi-gpta
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angularjs-asp-net48-mvc5/pull/98?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angularjs-asp-net48-mvc5/pull/98" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->