### PR TITLE
React migration (PR 2/6): Settings context & utility layer

### DIFF
--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -1,0 +1,87 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import type { ReactNode } from 'react';
+import type {
+  ResolvedTheme,
+  Settings,
+  ThemePreference,
+} from '../types/settings';
+import { DEFAULT_SETTINGS } from '../types/settings';
+
+const STORAGE_KEY = 'app-settings';
+
+function loadSettings(): Settings {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      return { ...DEFAULT_SETTINGS, ...JSON.parse(raw) };
+    }
+  } catch {
+    // ignore corrupt data
+  }
+  return DEFAULT_SETTINGS;
+}
+
+function saveSettings(settings: Settings): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+}
+
+interface SettingsContextValue {
+  settings: Settings;
+  resolvedTheme: ResolvedTheme;
+  setTheme: (theme: ThemePreference) => void;
+}
+
+const SettingsContext = createContext<SettingsContextValue | null>(null);
+
+export function SettingsProvider({ children }: { children: ReactNode }) {
+  const [settings, setSettings] = useState<Settings>(loadSettings);
+  const [systemDark, setSystemDark] = useState(false);
+
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    setSystemDark(mq.matches);
+
+    const handler = (e: MediaQueryListEvent) => setSystemDark(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+
+  useEffect(() => {
+    saveSettings(settings);
+  }, [settings]);
+
+  const resolvedTheme: ResolvedTheme = useMemo(() => {
+    if (settings.theme === 'system') {
+      return systemDark ? 'dark' : 'light';
+    }
+    return settings.theme;
+  }, [settings.theme, systemDark]);
+
+  const setTheme = useCallback((theme: ThemePreference) => {
+    setSettings((prev) => ({ ...prev, theme }));
+  }, []);
+
+  const value: SettingsContextValue = useMemo(
+    () => ({ settings, resolvedTheme, setTheme }),
+    [settings, resolvedTheme, setTheme],
+  );
+
+  return (
+    <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>
+  );
+}
+
+export function useSettings(): SettingsContextValue {
+  const ctx = useContext(SettingsContext);
+  if (!ctx) {
+    throw new Error('useSettings must be used within a SettingsProvider');
+  }
+  return ctx;
+}

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,0 +1,12 @@
+export type ThemePreference = 'light' | 'dark' | 'system';
+
+export type ResolvedTheme = 'light' | 'dark';
+
+export interface Settings {
+  /** The user's chosen theme preference. */
+  theme: ThemePreference;
+}
+
+export const DEFAULT_SETTINGS: Settings = {
+  theme: 'system',
+};

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,0 +1,5 @@
+import { version } from 'react';
+
+export function getReactVersion(): string {
+  return version;
+}


### PR DESCRIPTION
## Summary
Second of 6 sequential PRs (branches off PR 1). Adds the React context and utility layer that later components consume.

**The original Angular app had no services, filters, or pipes** (confirmed by `MIGRATION_AUDIT.md` sections 4-7) so there is no API layer to port. Instead, this PR creates the foundational pieces the playbook calls for:

- **`src/types/settings.ts`** — `Settings` interface with `ThemePreference` (`'light' | 'dark' | 'system'`), `ResolvedTheme`, and `DEFAULT_SETTINGS`.
- **`src/context/SettingsContext.tsx`** — `SettingsProvider` + `useSettings()` hook:
  - `useState` for settings state, initialized from `localStorage` (key `app-settings`).
  - `useEffect` for `prefers-color-scheme` media-query detection → `systemDark` state.
  - `resolvedTheme` derived via `useMemo`; persists on every mutation via `useEffect`.
  - Exposes `setTheme(theme: ThemePreference)`.
- **`src/utils/version.ts`** — `getReactVersion()` wrapping `react.version` (replaces Angular `VERSION.full` used by the two components, ported in PR 3).

`npm run build` passes.


Link to Devin session: https://app.devin.ai/sessions/33a617593b324e4dbd0503cb1db4ab58
Requested by: @devanshi-gpta
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angularjs-asp-net48-mvc5/pull/104?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angularjs-asp-net48-mvc5/pull/104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->