### PR TITLE
React migration (PR 3/6): Shared & layout components

### DIFF
--- a/src/components/ErrorMessage/ErrorMessage.module.scss
+++ b/src/components/ErrorMessage/ErrorMessage.module.scss
@@ -1,0 +1,12 @@
+.error {
+  padding: 1rem 1.5rem;
+  margin: 1rem;
+  border-left: 4px solid var(--hot-red);
+  background: color-mix(in srgb, var(--hot-red) 8%, transparent);
+  border-radius: 4px;
+
+  p {
+    margin: 0;
+    color: var(--gray-900);
+  }
+}

--- a/src/components/ErrorMessage/ErrorMessage.tsx
+++ b/src/components/ErrorMessage/ErrorMessage.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+import styles from './ErrorMessage.module.scss';
+
+interface ErrorMessageProps {
+  message?: string;
+}
+
+export default function ErrorMessage({ message }: ErrorMessageProps) {
+  const [offline, setOffline] = useState(!navigator.onLine);
+
+  useEffect(() => {
+    const goOffline = () => setOffline(true);
+    const goOnline = () => setOffline(false);
+    window.addEventListener('offline', goOffline);
+    window.addEventListener('online', goOnline);
+    return () => {
+      window.removeEventListener('offline', goOffline);
+      window.removeEventListener('online', goOnline);
+    };
+  }, []);
+
+  const text = offline
+    ? 'You appear to be offline. Please check your connection.'
+    : message ?? 'An unexpected error occurred.';
+
+  return (
+    <div className={styles.error} role="alert">
+      <p>{text}</p>
+    </div>
+  );
+}

--- a/src/components/Footer/Footer.module.scss
+++ b/src/components/Footer/Footer.module.scss
@@ -1,0 +1,17 @@
+.footer {
+  text-align: center;
+  padding: 1rem;
+  font-size: 0.875rem;
+  color: var(--gray-700);
+  border-top: 1px solid var(--gray-400);
+  margin-top: auto;
+
+  a {
+    color: var(--bright-blue);
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,0 +1,13 @@
+import styles from './Footer.module.scss';
+
+export default function Footer() {
+  return (
+    <footer className={styles.footer}>
+      <p>
+        Built with <a href="https://react.dev" target="_blank" rel="noopener noreferrer">React</a>
+        {' '}&amp;{' '}
+        <a href="https://vite.dev" target="_blank" rel="noopener noreferrer">Vite</a>
+      </p>
+    </footer>
+  );
+}

--- a/src/components/Header/Header.module.scss
+++ b/src/components/Header/Header.module.scss
@@ -1,0 +1,33 @@
+.header {
+  background: var(--gray-900);
+  color: #fff;
+  padding: 0.5rem 1rem;
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.brand {
+  font-weight: 700;
+  font-size: 1rem;
+  color: #fff;
+  text-decoration: none;
+
+  &:hover {
+    opacity: 0.85;
+  }
+}
+
+.settingsToggle {
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 1.25rem;
+  cursor: pointer;
+  padding: 0.25rem;
+}

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+import { NavLink } from 'react-router-dom';
+import { useSettings } from '../../context/SettingsContext';
+import Settings from '../Settings/Settings';
+import styles from './Header.module.scss';
+
+export default function Header() {
+  const { resolvedTheme } = useSettings();
+  const [settingsOpen, setSettingsOpen] = useState(false);
+
+  return (
+    <header className={styles.header} data-theme={resolvedTheme}>
+      <nav className={styles.nav}>
+        <NavLink to="/" className={styles.brand} data-testid="title">
+          XLTS for AngularJS with .NET Framework
+        </NavLink>
+        <button
+          type="button"
+          className={styles.settingsToggle}
+          onClick={() => setSettingsOpen((o) => !o)}
+          aria-label="Toggle settings"
+        >
+          {settingsOpen ? '✕' : '⚙'}
+        </button>
+      </nav>
+      {settingsOpen && <Settings />}
+    </header>
+  );
+}

--- a/src/components/Loader/Loader.module.scss
+++ b/src/components/Loader/Loader.module.scss
@@ -1,0 +1,21 @@
+.loader {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem;
+}
+
+.spinner {
+  width: 2rem;
+  height: 2rem;
+  border: 3px solid var(--gray-400);
+  border-top-color: var(--bright-blue);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/components/Loader/Loader.tsx
+++ b/src/components/Loader/Loader.tsx
@@ -1,0 +1,9 @@
+import styles from './Loader.module.scss';
+
+export default function Loader() {
+  return (
+    <div className={styles.loader} role="status" aria-label="Loading">
+      <div className={styles.spinner} />
+    </div>
+  );
+}

--- a/src/components/Settings/Settings.module.scss
+++ b/src/components/Settings/Settings.module.scss
@@ -1,0 +1,27 @@
+.settings {
+  padding: 0.75rem 0;
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.fieldset {
+  border: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+
+  legend {
+    font-weight: 700;
+    margin-right: 0.5rem;
+  }
+}
+
+.option {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  cursor: pointer;
+  font-size: 0.875rem;
+}

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -1,0 +1,33 @@
+import { useSettings } from '../../context/SettingsContext';
+import type { ThemePreference } from '../../types/settings';
+import styles from './Settings.module.scss';
+
+const THEME_OPTIONS: { value: ThemePreference; label: string }[] = [
+  { value: 'light', label: 'Light' },
+  { value: 'dark', label: 'Dark' },
+  { value: 'system', label: 'System' },
+];
+
+export default function Settings() {
+  const { settings, setTheme } = useSettings();
+
+  return (
+    <div className={styles.settings}>
+      <fieldset className={styles.fieldset}>
+        <legend>Theme</legend>
+        {THEME_OPTIONS.map(({ value, label }) => (
+          <label key={value} className={styles.option}>
+            <input
+              type="radio"
+              name="theme"
+              value={value}
+              checked={settings.theme === value}
+              onChange={() => setTheme(value)}
+            />
+            {label}
+          </label>
+        ))}
+      </fieldset>
+    </div>
+  );
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="vite/client" />
+
+declare module '*.module.scss' {
+  const classes: { readonly [key: string]: string };
+  export default classes;
+}


### PR DESCRIPTION
## Summary
Third of 6 sequential PRs (branches off PR 2). Adds all shared/layout components using CSS Modules (`.module.scss`). These are wired into the app shell in PR 4.

**Components added** (each in `src/components/<Name>/`):

| Component | Description |
|-----------|-------------|
| `Loader` | Centered spinner with `@keyframes spin` CSS animation, `role="status"` |
| `ErrorMessage` | Error display with offline detection via `online`/`offline` window events |
| `Header` | App title as `<NavLink to="/">` with `data-testid="title"`, settings gear toggle → renders `<Settings />` inline |
| `Footer` | Static footer with React & Vite links |
| `Settings` | Theme radio buttons (`light`/`dark`/`system`) wired to `useSettings().setTheme()` |

Also adds `src/vite-env.d.ts` with `*.module.scss` type declaration for CSS Module imports.

`npm run build` passes.


Link to Devin session: https://app.devin.ai/sessions/33a617593b324e4dbd0503cb1db4ab58
Requested by: @devanshi-gpta
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angularjs-asp-net48-mvc5/pull/105?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angularjs-asp-net48-mvc5/pull/105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->