### PR TITLE
React migration (PR 4/6): Page components & routing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,35 @@
+import { lazy, Suspense } from 'react';
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
+import { SettingsProvider, useSettings } from './context/SettingsContext';
+import Header from './components/Header/Header';
+import Footer from './components/Footer/Footer';
+import Loader from './components/Loader/Loader';
+
+const Home = lazy(() => import('./pages/Home/Home'));
+
+function AppShell() {
+  const { resolvedTheme } = useSettings();
+
+  return (
+    <div className={`app-root theme-${resolvedTheme}`}>
+      <Header />
+      <Suspense fallback={<Loader />}>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
+      </Suspense>
+      <Footer />
+    </div>
+  );
+}
+
 export default function App() {
   return (
-    <main>
-      <h1>React migration in progress</h1>
-      <p>The application shell will be built out in the following migration PRs.</p>
-    </main>
+    <BrowserRouter>
+      <SettingsProvider>
+        <AppShell />
+      </SettingsProvider>
+    </BrowserRouter>
   );
 }

--- a/src/components/TestComponent/TestComponent.tsx
+++ b/src/components/TestComponent/TestComponent.tsx
@@ -1,0 +1,9 @@
+import { getReactVersion } from '../../utils/version';
+
+export default function TestComponent() {
+  return (
+    <div data-testid="react-version" className="test-component">
+      React Version: {getReactVersion()}
+    </div>
+  );
+}

--- a/src/components/TestDirective/TestDirective.tsx
+++ b/src/components/TestDirective/TestDirective.tsx
@@ -1,0 +1,9 @@
+import { getReactVersion } from '../../utils/version';
+
+export default function TestDirective() {
+  return (
+    <div data-testid="react-version-directive" className="test-directive">
+      React Version: {getReactVersion()}
+    </div>
+  );
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -15,3 +15,20 @@ body {
   -moz-osx-font-smoothing: grayscale;
   color: var(--gray-900);
 }
+
+.app-root {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.theme-dark {
+  --gray-900: oklch(95% 0.006 300.98);
+  --gray-700: oklch(78% 0.014 302.71);
+  --gray-400: oklch(40% 0.015 304.04);
+  background-color: oklch(15% 0.005 300);
+}
+
+.theme-light {
+  background-color: #fff;
+}

--- a/src/pages/Home/Home.module.scss
+++ b/src/pages/Home/Home.module.scss
@@ -1,0 +1,82 @@
+.main {
+  width: 100%;
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.content {
+  display: flex;
+  justify-content: space-around;
+  width: 100%;
+  max-width: 700px;
+  margin-bottom: 2rem;
+}
+
+.leftSide h1 {
+  font-size: 2.5rem;
+  margin: 0;
+  color: var(--gray-900);
+}
+
+.leftSide p {
+  margin-top: 1rem;
+  color: var(--gray-700);
+}
+
+.divider {
+  width: 1px;
+  background: var(--red-to-pink-to-purple-vertical-gradient);
+  margin-inline: 0.5rem;
+}
+
+.rightSide {
+  display: flex;
+  align-items: center;
+}
+
+.pillGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.pill {
+  display: inline-block;
+  background: color-mix(in srgb, var(--pill-accent) 8%, transparent);
+  color: var(--pill-accent);
+  padding: 0.375rem 0.75rem;
+  border-radius: 2rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-decoration: none;
+  transition: background 0.2s;
+
+  &:hover {
+    background: color-mix(in srgb, var(--pill-accent) 18%, transparent);
+  }
+}
+
+.versions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  color: var(--gray-700);
+}
+
+@media screen and (max-width: 650px) {
+  .content {
+    flex-direction: column;
+    width: max-content;
+  }
+
+  .divider {
+    height: 1px;
+    width: 100%;
+    background: var(--red-to-pink-to-purple-horizontal-gradient);
+    margin-block: 1.5rem;
+  }
+}

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,0 +1,41 @@
+import TestComponent from '../../components/TestComponent/TestComponent';
+import TestDirective from '../../components/TestDirective/TestDirective';
+import styles from './Home.module.scss';
+
+export default function Home() {
+  return (
+    <main className={styles.main}>
+      <div className={styles.content}>
+        <div className={styles.leftSide}>
+          <h1>Hello, React</h1>
+          <p>The application has been migrated from Angular to React + Vite.</p>
+        </div>
+        <div className={styles.divider} role="separator" aria-label="Divider" />
+        <div className={styles.rightSide}>
+          <div className={styles.pillGroup}>
+            {[
+              { title: 'React Docs', link: 'https://react.dev' },
+              { title: 'Vite Docs', link: 'https://vite.dev' },
+              { title: 'React Router', link: 'https://reactrouter.com' },
+              { title: 'TypeScript', link: 'https://www.typescriptlang.org' },
+            ].map((item) => (
+              <a
+                key={item.title}
+                className={styles.pill}
+                href={item.link}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {item.title}
+              </a>
+            ))}
+          </div>
+        </div>
+      </div>
+      <section className={styles.versions}>
+        <TestComponent />
+        <TestDirective />
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
Fourth of 6 sequential PRs (branches off PR 3). Ports the Angular components to React and wires up the full app shell with routing.

**Components ported:**
- `TestComponent` → `src/components/TestComponent/TestComponent.tsx` — displays `React Version: {version}` via `getReactVersion()`, `data-testid="react-version"`
- `TestDirectiveComponent` → `src/components/TestDirective/TestDirective.tsx` — same pattern, `data-testid="react-version-directive"`

**Page added:**
- `src/pages/Home/Home.tsx` (default export for lazy loading) — landing page ported from Angular's `app.html`: heading, doc-link pills (now pointing to React/Vite/TS docs), and renders both test components. CSS Modules for layout.

**App shell (`src/App.tsx`):**
```tsx
<BrowserRouter>
  <SettingsProvider>
    <div className={`app-root theme-${resolvedTheme}`}>
      <Header />
      <Suspense fallback={<Loader />}>
        <Routes>
          <Route path="/" element={<Home />} />   // lazy
          <Route path="*" element={<Navigate to="/" />} />
        </Routes>
      </Suspense>
      <Footer />
    </div>
  </SettingsProvider>
</BrowserRouter>
```

**Global styles (`src/index.scss`):** Added `.app-root` flex column layout and `.theme-dark`/`.theme-light` classes overriding CSS custom properties for dark mode support.

`npm run build` passes (49 modules bundled, Home chunk code-split).


Link to Devin session: https://app.devin.ai/sessions/33a617593b324e4dbd0503cb1db4ab58
Requested by: @devanshi-gpta
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angularjs-asp-net48-mvc5/pull/106?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angularjs-asp-net48-mvc5/pull/106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->